### PR TITLE
Make chipid fields pub for use elsewhere

### DIFF
--- a/crates/tftool/src/lib.rs
+++ b/crates/tftool/src/lib.rs
@@ -14,7 +14,6 @@ mod mac;
 
 const REGISTER_SIZE: usize = 72 * 1024 * 1024;
 
-#[cfg(not(feature = "tofino_regs"))]
 mod tofino_regs {
     use anyhow::{anyhow, Result};
 

--- a/crates/tofino/src/fuse.rs
+++ b/crates/tofino/src/fuse.rs
@@ -108,17 +108,17 @@ impl Fuse {
 
 /// Parsed version of the chip_id field in the Fuse struct
 pub struct ChipId {
-    fab: char,
-    lot: char,
-    lotnum0: char,
-    lotnum1: char,
-    lotnum2: char,
-    lotnum3: char,
-    wafer: u8,
-    xsign: u8,
-    x: u8,
-    ysign: u8,
-    y: u8,
+    pub fab: char,
+    pub lot: char,
+    pub lotnum0: char,
+    pub lotnum1: char,
+    pub lotnum2: char,
+    pub lotnum3: char,
+    pub wafer: u8,
+    pub xsign: u8,
+    pub x: u8,
+    pub ysign: u8,
+    pub y: u8,
 }
 
 impl From<u64> for ChipId {


### PR DESCRIPTION
Related to work in https://github.com/oxidecomputer/dendrite/pull/1031. 