### PR TITLE
Reduce amount of FFI code.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "rsf"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/rsf?branch=associated_types#f99d66f091f3e20bdb93f2a55dcce32e361c3a33"
+source = "git+https://github.com/oxidecomputer/rsf#9f3e0d9af3129baa4f193638c18f756430a15230"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "rust_rpi"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/rsf?branch=associated_types#f99d66f091f3e20bdb93f2a55dcce32e361c3a33"
+source = "git+https://github.com/oxidecomputer/rsf#9f3e0d9af3129baa4f193638c18f756430a15230"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "rsf"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/rsf?branch=associated_types#b2e9f1e76795256e4eb1197c79c6a1cc8c4d7e82"
+source = "git+https://github.com/oxidecomputer/rsf?branch=associated_types#f99d66f091f3e20bdb93f2a55dcce32e361c3a33"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "rust_rpi"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/rsf?branch=associated_types#b2e9f1e76795256e4eb1197c79c6a1cc8c4d7e82"
+source = "git+https://github.com/oxidecomputer/rsf?branch=associated_types#f99d66f091f3e20bdb93f2a55dcce32e361c3a33"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +172,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,9 +291,9 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -324,6 +336,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "getrandom"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,7 +360,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -350,6 +368,9 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -385,6 +406,19 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "iddqd"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616230c7d641ef971a3a5bfcc654c6b7524ab9c9fb665693c6a397dba9a14aca"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "hashbrown 0.16.1",
+ "rustc-hash",
+]
 
 [[package]]
 name = "illumos-devinfo"
@@ -466,6 +500,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -631,7 +677,7 @@ dependencies = [
 [[package]]
 name = "rsf"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/rsf#ba3b1c2df4beeeac5e34aa9b517f4aab74ca1028"
+source = "git+https://github.com/oxidecomputer/rsf?branch=associated_types#b2e9f1e76795256e4eb1197c79c6a1cc8c4d7e82"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -643,6 +689,7 @@ dependencies = [
  "colored",
  "convert_case 0.8.0",
  "expectorate",
+ "iddqd",
  "num_enum 0.7.5",
  "petgraph",
  "prettyplease",
@@ -657,7 +704,13 @@ dependencies = [
 [[package]]
 name = "rust_rpi"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/rsf#ba3b1c2df4beeeac5e34aa9b517f4aab74ca1028"
+source = "git+https://github.com/oxidecomputer/rsf?branch=associated_types#b2e9f1e76795256e4eb1197c79c6a1cc8c4d7e82"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -832,6 +885,8 @@ dependencies = [
  "anyhow",
  "cc",
  "illumos-devinfo",
+ "libc",
+ "nix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,6 @@ paste = "1.0"
 quote = "1.0.40"
 regex = "1.12"
 regs = { path = "regs" }
-rsf = { git = "https://github.com/oxidecomputer/rsf", branch = "associated_types" }
-rust_rpi = { git = "https://github.com/oxidecomputer/rsf", branch = "associated_types" }
+rsf = { git = "https://github.com/oxidecomputer/rsf" }
+rust_rpi = { git = "https://github.com/oxidecomputer/rsf" }
 tofino = { path = "tofino" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,12 @@ chrono = "0.4"
 clap = { version = "4.5.4", features = ["derive"] }
 convert_case = "0.11"
 illumos-devinfo = { git = "https://github.com/oxidecomputer/illumos-devinfo", branch = "main" }
+libc = "0.2.174"
+nix = { version = "0.31", features = ["poll"] }
 paste = "1.0"
 quote = "1.0.40"
 regex = "1.12"
-rsf = { git = "https://github.com/oxidecomputer/rsf" }
-rust_rpi = { git = "https://github.com/oxidecomputer/rsf" }
-tofino = { path = "tofino" }
 regs = { path = "regs" }
+rsf = { git = "https://github.com/oxidecomputer/rsf", branch = "associated_types" }
+rust_rpi = { git = "https://github.com/oxidecomputer/rsf", branch = "associated_types" }
+tofino = { path = "tofino" }

--- a/regs/Cargo.toml
+++ b/regs/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow.workspace = true
 bitset = { git = "https://github.com/oxidecomputer/bitset", branch = "main"}
-rust_rpi = { git = "https://github.com/oxidecomputer/rsf" }
+rust_rpi.workspace = true
 
 [build-dependencies]
 cc.workspace = true

--- a/regs/src/lib.rs
+++ b/regs/src/lib.rs
@@ -8,7 +8,6 @@
 
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
-#![feature(try_trait_v2)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]

--- a/rsf/tf2.rsf
+++ b/rsf/tf2.rsf
@@ -2185,9 +2185,9 @@ block TmCaaTop {
     ///jbay_reg.device_select.tm_top.tm_caa_top.blocks_freecnt
     blocks_freecnt: TmCaaTop_BlocksFreecnt @ 0x278,
     ///epipe
-    epipe: TmCaaTop_Epipe[0x10; 0xf] @ 0x1000,
+    epipe: TmCaaTop_Epipe[0x10; 0x18] @ 0x1000,
     ///block
-    block: TmCaaTop_Block[0xc0; 0x0] @ 0x2000,
+    block: TmCaaTop_Block[0xc0; 0xc] @ 0x2000,
     ///jbay_reg.device_select.tm_top.tm_caa_top.caa_bank_ctr
     caa_bank_ctr: CaaBankCtr[0x180; 0x4] @ 0x3000,
     ///jbay_reg.device_select.tm_top.tm_caa_top.lmem_indir_access_addr
@@ -3305,7 +3305,7 @@ block PscCommon {
     ///epipe
     epipe: PscCommon_Epipe[0x4; 0x18] @ 0x800,
     ///block
-    block: PscCommon_Block[0x60; 0x1] @ 0x1000,
+    block: PscCommon_Block[0x60; 0xc] @ 0x1000,
     ///jbay_reg.device_select.tm_top.tm_psc_top.psc_common.psc_bank_ctrl_r
     psc_bank_ctrl_r: PscBankCtrlR[0x180; 0x4] @ 0x1800,
     ///jbay_reg.device_select.tm_top.tm_psc_top.psc_common.lmem_indir_access_addr
@@ -5367,7 +5367,7 @@ block GpioIotileTr {
 ///main.pipes[0]
 block Pipes {
     ///mau
-    mau: Mau[0x14; 0x40000] @ 0x0,
+    mau: Mau[0x14; 0x80000] @ 0x0,
     ///pardereg
     pardereg: Pardereg @ 0xc00000,
 }
@@ -5453,23 +5453,23 @@ block Dp {
 ///main.pipes[0].mau[0].dp.imem
 block Imem {
     ///jbay_reg.pipes.mau.dp.imem.imem_mocha_subword16
-    imem_mocha_subword16: ImemMochaSubword16[0x2; 0x800] @ 0x0,
+    imem_mocha_subword16: ImemMochaSubword16[0x400; 0x4] @ 0x0,
     ///jbay_reg.pipes.mau.dp.imem.imem_dark_subword16
-    imem_dark_subword16: ImemDarkSubword16[0x2; 0x800] @ 0x1000,
+    imem_dark_subword16: ImemDarkSubword16[0x400; 0x4] @ 0x1000,
     ///jbay_reg.pipes.mau.dp.imem.imem_mocha_subword32
-    imem_mocha_subword32: ImemMochaSubword32[0x2; 0x400] @ 0x2000,
+    imem_mocha_subword32: ImemMochaSubword32[0x200; 0x4] @ 0x2000,
     ///jbay_reg.pipes.mau.dp.imem.imem_mocha_subword8
-    imem_mocha_subword8: ImemMochaSubword8[0x2; 0x400] @ 0x2800,
+    imem_mocha_subword8: ImemMochaSubword8[0x200; 0x4] @ 0x2800,
     ///jbay_reg.pipes.mau.dp.imem.imem_dark_subword32
-    imem_dark_subword32: ImemDarkSubword32[0x2; 0x400] @ 0x3000,
+    imem_dark_subword32: ImemDarkSubword32[0x200; 0x4] @ 0x3000,
     ///jbay_reg.pipes.mau.dp.imem.imem_dark_subword8
-    imem_dark_subword8: ImemDarkSubword8[0x2; 0x400] @ 0x3800,
+    imem_dark_subword8: ImemDarkSubword8[0x200; 0x4] @ 0x3800,
     ///jbay_reg.pipes.mau.dp.imem.imem_subword16
-    imem_subword16: ImemSubword16[0x2; 0x2000] @ 0x8000,
+    imem_subword16: ImemSubword16[0x1000; 0x4] @ 0x8000,
     ///jbay_reg.pipes.mau.dp.imem.imem_subword32
-    imem_subword32: ImemSubword32[0x2; 0x1000] @ 0xc000,
+    imem_subword32: ImemSubword32[0x800; 0x4] @ 0xc000,
     ///jbay_reg.pipes.mau.dp.imem.imem_subword8
-    imem_subword8: ImemSubword8[0x2; 0x1000] @ 0xe000,
+    imem_subword8: ImemSubword8[0x800; 0x4] @ 0xe000,
 }
 
 ///main.pipes[0].mau[0].dp.snapshot_ctl
@@ -5501,25 +5501,25 @@ block SnapshotDp {
 ///main.pipes[0].mau[0].dp.snapshot_dp.snapshot_capture[0]
 block SnapshotCapture {
     ///jbay_reg.pipes.mau.dp.snapshot_dp.snapshot_capture.mau_snapshot_capture_subword32b_lo
-    mau_snapshot_capture_subword32b_lo: MauSnapshotCaptureSubword32BLo[0x14; 0x8] @ 0x0,
+    mau_snapshot_capture_subword32b_lo: MauSnapshotCaptureSubword32BLo[0x28; 0x4] @ 0x0,
     ///jbay_reg.pipes.mau.dp.snapshot_dp.snapshot_capture.mau_snapshot_capture_subword32b_hi
-    mau_snapshot_capture_subword32b_hi: MauSnapshotCaptureSubword32BHi[0x14; 0x8] @ 0x100,
+    mau_snapshot_capture_subword32b_hi: MauSnapshotCaptureSubword32BHi[0x28; 0x4] @ 0x100,
     ///jbay_reg.pipes.mau.dp.snapshot_dp.snapshot_capture.mau_snapshot_capture_subword8b
-    mau_snapshot_capture_subword8b: MauSnapshotCaptureSubword8B[0x14; 0x8] @ 0x400,
+    mau_snapshot_capture_subword8b: MauSnapshotCaptureSubword8B[0x28; 0x4] @ 0x400,
     ///jbay_reg.pipes.mau.dp.snapshot_dp.snapshot_capture.mau_snapshot_capture_subword16b
-    mau_snapshot_capture_subword16b: MauSnapshotCaptureSubword16B[0x14; 0x10] @ 0x600,
+    mau_snapshot_capture_subword16b: MauSnapshotCaptureSubword16B[0x50; 0x4] @ 0x600,
 }
 
 ///main.pipes[0].mau[0].dp.snapshot_dp.snapshot_match
 block SnapshotMatch {
     ///jbay_reg.pipes.mau.dp.snapshot_dp.snapshot_match.mau_snapshot_match_subword32b_lo
-    mau_snapshot_match_subword32b_lo: MauSnapshotMatchSubword32BLo[0x40; 0x8] @ 0x0,
+    mau_snapshot_match_subword32b_lo: MauSnapshotMatchSubword32BLo[0x80; 0x4] @ 0x0,
     ///jbay_reg.pipes.mau.dp.snapshot_dp.snapshot_match.mau_snapshot_match_subword32b_hi
-    mau_snapshot_match_subword32b_hi: MauSnapshotMatchSubword32BHi[0x40; 0x8] @ 0x200,
+    mau_snapshot_match_subword32b_hi: MauSnapshotMatchSubword32BHi[0x80; 0x4] @ 0x200,
     ///jbay_reg.pipes.mau.dp.snapshot_dp.snapshot_match.mau_snapshot_match_subword8b
-    mau_snapshot_match_subword8b: MauSnapshotMatchSubword8B[0x40; 0x8] @ 0x800,
+    mau_snapshot_match_subword8b: MauSnapshotMatchSubword8B[0x80; 0x4] @ 0x800,
     ///jbay_reg.pipes.mau.dp.snapshot_dp.snapshot_match.mau_snapshot_match_subword16b
-    mau_snapshot_match_subword16b: MauSnapshotMatchSubword16B[0x60; 0x8] @ 0xc00,
+    mau_snapshot_match_subword16b: MauSnapshotMatchSubword16B[0xc0; 0x4] @ 0xc00,
 }
 
 ///main.pipes[0].mau[0].dp.xbar_hash
@@ -5533,7 +5533,7 @@ block XbarHash_Hash {
     ///jbay_reg.pipes.mau.dp.xbar_hash.hash.hash_seed
     hash_seed: Hash_HashSeed[0x34; 0x4] @ 0x100,
     ///jbay_reg.pipes.mau.dp.xbar_hash.hash.galois_field_matrix
-    galois_field_matrix: GaloisFieldMatrix[0x40; 0x100] @ 0x4000,
+    galois_field_matrix: GaloisFieldMatrix[0x1000; 0x4] @ 0x4000,
 }
 
 ///main.pipes[0].mau[0].rams
@@ -5555,7 +5555,7 @@ block Array {
 ///main.pipes[0].mau[0].rams.array.row[0]
 block Array_Row {
     ///ram
-    ram: Ram[0xc; 0x6a] @ 0x0,
+    ram: Ram[0xc; 0x80] @ 0x0,
     ///stash
     stash: Stash @ 0xd00,
     ///jbay_reg.pipes.mau.rams.array.row.intr_status_mau_unit_ram_row
@@ -5589,9 +5589,9 @@ block Stash {
     ///jbay_reg.pipes.mau.rams.array.row.stash.stash_match_input_data_ctl
     stash_match_input_data_ctl: StashMatchInputDataCtl[0x2; 0x4] @ 0x30,
     ///jbay_reg.pipes.mau.rams.array.row.stash.stash_data
-    stash_data: StashData[0x4; 0x10] @ 0x80,
+    stash_data: StashData[0x10; 0x4] @ 0x80,
     ///jbay_reg.pipes.mau.rams.array.row.stash.stash_match_mask
-    stash_match_mask: StashMatchMask[0x2; 0x10] @ 0xc0,
+    stash_match_mask: StashMatchMask[0x8; 0x4] @ 0xc0,
     ///jbay_reg.pipes.mau.rams.array.row.stash.stash_hashkey_data
     stash_hashkey_data: StashHashkeyData[0x4; 0x4] @ 0xf0,
 }
@@ -5603,7 +5603,7 @@ block MapAlu {
     ///jbay_reg.pipes.mau.rams.map_alu.intr_mau_decode_memory_core
     intr_mau_decode_memory_core: IntrMauDecodeMemoryCore[0x2; 0x4] @ 0x2120,
     ///jbay_reg.pipes.mau.rams.map_alu.selector_action_adr_fallback
-    selector_action_adr_fallback: SelectorActionAdrFallback[0x8; 0x8] @ 0x24c0,
+    selector_action_adr_fallback: SelectorActionAdrFallback[0x10; 0x4] @ 0x24c0,
     ///stats_wrap
     stats_wrap: StatsWrap[0x4; 0x80] @ 0x2600,
     ///meter_group
@@ -5741,7 +5741,7 @@ block Merge {
     ///jbay_reg.pipes.mau.rams.match.merge.mpr_glob_exec_lut
     mpr_glob_exec_lut: MprGlobExecLut[0x10; 0x4] @ 0x40,
     ///jbay_reg.pipes.mau.rams.match.merge.stash_next_table_lut
-    stash_next_table_lut: StashNextTableLut[0x2; 0x20] @ 0xc0,
+    stash_next_table_lut: StashNextTableLut[0x10; 0x4] @ 0xc0,
     ///jbay_reg.pipes.mau.rams.match.merge.mau_snapshot_physical_tcam_hit_address
     mau_snapshot_physical_tcam_hit_address: MauSnapshotPhysicalTcamHitAddress[0x10; 0x4] @ 0x280,
     ///jbay_reg.pipes.mau.rams.match.merge.mau_snapshot_physical_exact_match_hit_address
@@ -5783,7 +5783,7 @@ block Merge {
     ///jbay_reg.pipes.mau.rams.match.merge.pred_stage_id
     pred_stage_id: PredStageId @ 0x14f0,
     ///jbay_reg.pipes.mau.rams.match.merge.mpr_next_table_lut
-    mpr_next_table_lut: MprNextTableLut[0x3; 0x40] @ 0x2a00,
+    mpr_next_table_lut: MprNextTableLut[0x30; 0x4] @ 0x2a00,
     ///jbay_reg.pipes.mau.rams.match.merge.mpr_glob_exec_thread
     mpr_glob_exec_thread: MprGlobExecThread @ 0x2c28,
     ///jbay_reg.pipes.mau.rams.match.merge.mpr_long_brch_thread
@@ -8023,7 +8023,7 @@ block Pgluereg_PardeIntr {
 ///main.pipes[0].pardereg.pgstnreg.pgrreg
 block Pgrreg {
     ///pgr_app
-    pgr_app: PgrApp[0x10; 0x140] @ 0x0,
+    pgr_app: PgrApp[0x10; 0x200] @ 0x0,
     ///pgr_common
     pgr_common: PgrCommon @ 0x2000,
 }

--- a/tofino/Cargo.toml
+++ b/tofino/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2024"
 
 [dependencies]
 anyhow.workspace = true
+libc.workspace = true
+nix.workspace = true
 
 [target.'cfg(target_os = "illumos")'.dependencies]
 illumos-devinfo.workspace = true

--- a/tofino/src/c/pci.c
+++ b/tofino/src/c/pci.c
@@ -28,31 +28,10 @@ pci_err_msg() {
 	}
 }
 
-static int
-pci_open(const char *path)
-{
-	int fd;
-
-	bzero(err_msg, MAX_ERR_LEN + 1);
-	fd = open(path, O_RDWR | O_EXCL);
-	if (fd < 0) {
-		snprintf(err_msg, MAX_ERR_LEN,
-		    "failed to open device: %s", strerror(errno));
-		return -1;
-	}
-	return fd;
-}
-
 void *
-pci_map(const char *path, size_t len)
+pci_map(int fd, size_t len)
 {
-	int fd;
-
 	bzero(err_msg, MAX_ERR_LEN + 1);
-	fd = pci_open(path);
-	if (fd < 0)
-		return NULL;
-
 	caddr_t base = mmap(NULL, len, PROT_READ | PROT_WRITE,
 	    MAP_SHARED, fd, 0);
 	if (base == MAP_FAILED) {
@@ -64,15 +43,8 @@ pci_map(const char *path, size_t len)
 	return base;
 }
 
-int
-pci_check_presence(const char *path)
+void
+pci_unmap(void *base, size_t len)
 {
-	bzero(err_msg, MAX_ERR_LEN + 1);
-	int fd = pci_open(path);
-	if (fd < 0) {
-		return -1;
-	} else {
-		close(fd);
-		return 0;
-	}
+	munmap(base, len);
 }

--- a/tofino/src/c/pci.h
+++ b/tofino/src/c/pci.h
@@ -11,7 +11,8 @@
 
 #include <sys/types.h>
 
-extern void *pci_map(const char *path, size_t size);
+extern void *pci_map(int fd, size_t size);
+extern void pci_unmap(void *base, size_t size);
 extern const char *pci_err_msg() ;
 
 #endif

--- a/tofino/src/lib.rs
+++ b/tofino/src/lib.rs
@@ -4,13 +4,14 @@
 
 // Copyright 2023 Oxide Computer Company
 
-use anyhow::{Error, Result};
+use anyhow::{Error, Result, anyhow};
+use std::os::fd::AsRawFd;
 
 pub mod common;
 pub mod fuse;
 pub mod pci;
 
-pub const REGISTER_SIZE: usize = 72 * 1024 * 1024;
+pub const REGISTER_SIZE: usize = 128 * 1024 * 1024;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct TofinoNode {
@@ -19,6 +20,14 @@ pub struct TofinoNode {
     pub instance: Option<i32>,
     pub available: bool,
     pub devfs_path: String,
+}
+
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct DriverVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
 }
 
 impl TofinoNode {
@@ -35,6 +44,24 @@ impl TofinoNode {
     /// Return true iff there is a tofino asic visible in the PCI hierarchy
     pub fn has_asic(&self) -> bool {
         self.instance.is_some()
+    }
+
+    pub fn driver_version(&self) -> Result<DriverVersion> {
+        const VERSION_IOCTL: u32 = 0x1d1c1002;
+        let mut version = DriverVersion { major: 0, minor: 0, patch: 0 };
+        if self.driver.is_none() {
+            return Err(anyhow!("no driver found"));
+        }
+
+        let path = plat::device_path(self)?;
+        let f = std::fs::OpenOptions::new().read(true).open(path)?;
+        if unsafe {
+            libc::ioctl(f.as_raw_fd(), VERSION_IOCTL as _, &mut version)
+        } == -1
+        {
+            return Err(anyhow!("{:?}", std::io::Error::last_os_error()));
+        }
+        Ok(version)
     }
 
     /// Open the tofino device, map the register space, and return a handle

--- a/tofino/src/lib.rs
+++ b/tofino/src/lib.rs
@@ -12,6 +12,7 @@ pub mod fuse;
 pub mod pci;
 
 pub const REGISTER_SIZE: usize = 128 * 1024 * 1024;
+const VERSION_IOCTL: u32 = 0x1d1c1002;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct TofinoNode {
@@ -47,21 +48,12 @@ impl TofinoNode {
     }
 
     pub fn driver_version(&self) -> Result<DriverVersion> {
-        const VERSION_IOCTL: u32 = 0x1d1c1002;
-        let mut version = DriverVersion { major: 0, minor: 0, patch: 0 };
         if self.driver.is_none() {
             return Err(anyhow!("no driver found"));
         }
 
         let path = plat::device_path(self)?;
-        let f = std::fs::OpenOptions::new().read(true).open(path)?;
-        if unsafe {
-            libc::ioctl(f.as_raw_fd(), VERSION_IOCTL as _, &mut version)
-        } == -1
-        {
-            return Err(anyhow!("{:?}", std::io::Error::last_os_error()));
-        }
-        Ok(version)
+        get_driver_version(&path)
     }
 
     /// Open the tofino device, map the register space, and return a handle
@@ -199,4 +191,17 @@ pub fn get_tofino_from_devinfo(
 pub fn get_tofino() -> Result<Option<TofinoNode>> {
     let mut all = plat::get_tofino_nodes()?;
     Ok(all.pop())
+}
+
+/// If the given path corresponds to a tofino device node, return the version
+/// of the driver providing that node.
+pub fn get_driver_version(path: &str) -> Result<DriverVersion> {
+    let mut version = DriverVersion { major: 0, minor: 0, patch: 0 };
+    let f = std::fs::OpenOptions::new().read(true).open(path)?;
+    if unsafe { libc::ioctl(f.as_raw_fd(), VERSION_IOCTL as _, &mut version) }
+        == -1
+    {
+        return Err(anyhow!("{:?}", std::io::Error::last_os_error()));
+    }
+    Ok(version)
 }

--- a/tofino/src/pci.rs
+++ b/tofino/src/pci.rs
@@ -6,14 +6,23 @@
 
 /// This provides a small number of utility routines for accessing the
 /// ASIC's memory mapped PCI space.
+use std::ffi::CStr;
+use std::fs::File;
+use std::io::Read;
+use std::os::fd::AsFd;
+use std::os::fd::AsRawFd;
+
 use anyhow::{Result, anyhow};
-use std::ffi::{CStr, CString};
+use nix::poll;
 
 unsafe extern "C" {
+    pub fn pci_open(path: *const ::std::os::raw::c_char) -> ::core::ffi::c_int;
+    pub fn pci_close(fd: ::core::ffi::c_int);
     pub fn pci_map(
-        path: *const ::std::os::raw::c_char,
+        fd: ::core::ffi::c_int,
         size: usize,
     ) -> *mut ::core::ffi::c_void;
+    pub fn pci_unmap(base: *mut ::core::ffi::c_void, size: usize);
     pub fn pci_check_presence(
         path: *const ::std::os::raw::c_char,
     ) -> ::core::ffi::c_int;
@@ -22,17 +31,28 @@ unsafe extern "C" {
 
 /// A handle representing a mapped ASIC device
 pub struct Pci {
+    dev_file: File,
     ptr: *mut ::core::ffi::c_void,
     len: usize,
+}
+
+impl Drop for Pci {
+    fn drop(&mut self) {
+        unsafe {
+            pci_unmap(self.ptr, self.len);
+        };
+    }
+}
+
+fn open_device_file(path: &str) -> std::io::Result<File> {
+    std::fs::OpenOptions::new().read(true).write(true).open(path)
 }
 
 impl Pci {
     /// Open the ASIC and map the BAR containing the config/status registers.
     pub fn new(path: &str, len: usize) -> Result<Self> {
-        let ptr = unsafe {
-            let path = CString::new(path).unwrap();
-            pci_map(path.as_ptr(), len)
-        };
+        let dev_file = open_device_file(path)?;
+        let ptr = unsafe { pci_map(dev_file.as_raw_fd(), len) };
 
         if ptr.is_null() {
             let msg = unsafe {
@@ -40,17 +60,40 @@ impl Pci {
             };
             Err(anyhow!("failed to map {}: {}", path, msg))
         } else {
-            Ok(Pci { ptr, len })
+            Ok(Pci { dev_file, ptr, len })
         }
+    }
+
+    /// Block until the underlying device file becomes "readable".  For this
+    /// driver, this means that one or more interrupts have been caught, and
+    /// the exported shadow interrupt bitmap has been updated.
+    pub fn poll(&self, timeout: std::time::Duration) -> Result<bool> {
+        let fd = self.dev_file.as_fd();
+        let mut pollfds = [poll::PollFd::new(fd, poll::PollFlags::POLLRDNORM)];
+
+        let timeout = poll::PollTimeout::try_from(timeout).map_err(|e| {
+            anyhow::anyhow!(format!("invalid timeout {timeout:?}: {e:?}"))
+        })?;
+
+        poll::poll(&mut pollfds, timeout)
+            .map_err(|e| anyhow::anyhow!("poll failed: {e:?}"))
+            .map(|nready| nready > 0)
+    }
+
+    /// Fetches the set of shadow interrupt bits, indicating which interrupts
+    ///  have fired since the last time this process issued this read.
+    pub fn read_shadow_bits(&mut self) -> Result<Vec<u8>> {
+        let mut buffer = [0u8; 64];
+        self.dev_file
+            .read(&mut buffer)
+            .map_err(|e| anyhow!(format!("failed to read shadow bits: {e:?}")))
+            .map(|r| buffer[0..r].to_vec())
     }
 
     /// Attempt to open the device file, just to determine whether the
     /// underlying ASIC is still available.
     pub fn check_presence(path: &str) -> bool {
-        unsafe {
-            let path = CString::new(path).unwrap();
-            pci_check_presence(path.as_ptr()) >= 0
-        }
+        open_device_file(path).is_ok()
     }
 
     fn get_word_ptr(&self, offset: u32) -> Result<*mut u32> {

--- a/tofino/src/pci.rs
+++ b/tofino/src/pci.rs
@@ -65,8 +65,7 @@ impl Pci {
     }
 
     /// Block until the underlying device file becomes "readable".  For this
-    /// driver, this means that one or more interrupts have been caught, and
-    /// the exported shadow interrupt bitmap has been updated.
+    /// driver, this means that one or more interrupts have been caught.
     pub fn poll(&self, timeout: std::time::Duration) -> Result<bool> {
         let fd = self.dev_file.as_fd();
         let mut pollfds = [poll::PollFd::new(fd, poll::PollFlags::POLLRDNORM)];
@@ -80,14 +79,19 @@ impl Pci {
             .map(|nready| nready > 0)
     }
 
-    /// Fetches the set of shadow interrupt bits, indicating which interrupts
-    ///  have fired since the last time this process issued this read.
-    pub fn read_shadow_bits(&mut self) -> Result<Vec<u8>> {
-        let mut buffer = [0u8; 64];
-        self.dev_file
-            .read(&mut buffer)
-            .map_err(|e| anyhow!(format!("failed to read shadow bits: {e:?}")))
-            .map(|r| buffer[0..r].to_vec())
+    /// Fetches the set of interrupt counts, indicating which interrupts
+    /// have fired since the last time this process issued this read.
+    pub fn read_interrupt_counts(&mut self) -> Result<Vec<u32>> {
+        let mut buffer = [0u8; 8];
+        match self.dev_file.read(&mut buffer).map_err(|e| {
+            anyhow!(format!("failed to read shadow bits: {e:?}"))
+        })? {
+            r if r == 8 => Ok(vec![
+                u32::from_ne_bytes(buffer[0..4].try_into().unwrap()),
+                u32::from_ne_bytes(buffer[4..8].try_into().unwrap()),
+            ]),
+            r => Err(anyhow!(format!("found {r} bytes of interrupt data"))),
+        }
     }
 
     /// Attempt to open the device file, just to determine whether the

--- a/tofino/src/pci.rs
+++ b/tofino/src/pci.rs
@@ -81,15 +81,12 @@ impl Pci {
 
     /// Fetches the set of interrupt counts, indicating which interrupts
     /// have fired since the last time this process issued this read.
-    pub fn read_interrupt_counts(&mut self) -> Result<Vec<u32>> {
+    pub fn read_interrupt_count(&mut self) -> Result<u32> {
         let mut buffer = [0u8; 8];
         match self.dev_file.read(&mut buffer).map_err(|e| {
             anyhow!(format!("failed to read shadow bits: {e:?}"))
         })? {
-            8 => Ok(vec![
-                u32::from_ne_bytes(buffer[0..4].try_into().unwrap()),
-                u32::from_ne_bytes(buffer[4..8].try_into().unwrap()),
-            ]),
+            8 => Ok(u32::from_ne_bytes(buffer[0..4].try_into().unwrap())),
             r => Err(anyhow!(format!("found {r} bytes of interrupt data"))),
         }
     }

--- a/tofino/src/pci.rs
+++ b/tofino/src/pci.rs
@@ -86,7 +86,7 @@ impl Pci {
         match self.dev_file.read(&mut buffer).map_err(|e| {
             anyhow!(format!("failed to read shadow bits: {e:?}"))
         })? {
-            r if r == 8 => Ok(vec![
+            8 => Ok(vec![
                 u32::from_ne_bytes(buffer[0..4].try_into().unwrap()),
                 u32::from_ne_bytes(buffer[4..8].try_into().unwrap()),
             ]),

--- a/xml2rsf/src/parse.rs
+++ b/xml2rsf/src/parse.rs
@@ -1,5 +1,7 @@
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufReader, prelude::*};
+use std::sync::OnceLock;
 
 use anyhow::Result;
 use anyhow::anyhow;
@@ -7,9 +9,32 @@ use anyhow::bail;
 use convert_case::{Case, Casing};
 use regex::Regex;
 
+struct Regexes {
+    pub offset_re: regex::Regex,
+    pub array_re: regex::Regex,
+    pub bounds_re: regex::Regex,
+    pub csr_re: regex::Regex,
+}
+
+static REGEXES: OnceLock<Regexes> = OnceLock::new();
+
 pub struct RegMap {
     pub address_maps: Vec<AddressMap>,
     pub registers: Vec<Register>,
+    pub arrays: BTreeMap<String, ArrayInfo>,
+}
+
+fn init_regexes() {
+    let _ = REGEXES.get_or_init(|| Regexes {
+        offset_re: regex::Regex::new(
+            r"\s*(0x[[:xdigit:]]+) - 0x([[:xdigit:]]+), \+0x([[:xdigit:]]+)\s*",
+        )
+        .unwrap(),
+        array_re: Regex::new(r"(\d+ - \d+)").unwrap(),
+        bounds_re: Regex::new(r"(\d+) - (\d+)").unwrap(),
+        csr_re: Regex::new(r"\s*(<csr:([^>]*)>)?([^<]*)(</csr:([^>]*)>)?\s*")
+            .unwrap(),
+    });
 }
 
 #[derive(Debug)]
@@ -58,7 +83,7 @@ pub struct AddressMap {
 impl TryFrom<&RawNode> for AddressMap {
     type Error = anyhow::Error;
     fn try_from(node: &RawNode) -> std::result::Result<Self, Self::Error> {
-        match node {
+        match node.find_descendant_container("addressMap").unwrap() {
             RawNode::Container { children, .. } => {
                 let all = children.len();
                 let entries = children
@@ -105,6 +130,12 @@ fn access_parse(s: &str) -> Result<AccessMode> {
         "r/w1c" => Ok(AccessMode::ReadWrite1Clear),
         x => bail!("unrecognized access type: {}", x),
     }
+}
+
+#[derive(Debug)]
+pub struct ArrayInfo {
+    pub size: u32,
+    pub spacing: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -254,7 +285,6 @@ enum LineType {
 struct Parser<R: std::io::Read> {
     line_no: u32,
     reader: BufReader<R>,
-    re: Regex,
 }
 
 impl<R> Parser<R>
@@ -262,16 +292,11 @@ where
     R: std::io::Read,
 {
     pub fn new(reader: BufReader<R>) -> Self {
-        Parser {
-            line_no: 0,
-            reader,
-            re: Regex::new(r"\s*(<csr:([^>]*)>)?([^<]*)(</csr:([^>]*)>)?\s*")
-                .unwrap(),
-        }
+        Parser { line_no: 0, reader }
     }
 
     fn classify_line(&self, line: &str) -> Result<LineType> {
-        let c = self.re.captures(line).unwrap();
+        let c = REGEXES.get().unwrap().csr_re.captures(line).unwrap();
         let tag1 = c.get(2).map(|m| m.as_str());
         let body = c.get(3).unwrap().as_str();
         let tag2 = c.get(5).map(|m| m.as_str());
@@ -365,6 +390,29 @@ where
     }
 }
 
+// Each array has two bits of informtion:
+//   The array dimensions:
+//      <csr:arrayDimensions>[0 - 3]</csr:arrayDimensions>
+//      <csr:arrayDimensions>[0 - 63][0 - 63]</csr:arrayDimensions>
+//   The offset - from which we extract the spacing between elements:
+//      <csr:offset>0x0 - 0xC, +0x4</csr:offset>
+fn get_array_info(n: &RawNode) -> Option<ArrayInfo> {
+    let Ok(dim) = n.get_child_value("arrayDimensions") else {
+        return None;
+    };
+    let mut size = 1;
+    for d in REGEXES.get().unwrap().array_re.find_iter(&dim) {
+        let b = REGEXES.get().unwrap().bounds_re.captures(d.as_str()).unwrap();
+        let upper = b.get(2).unwrap().as_str().parse::<u32>().unwrap();
+        size *= upper + 1;
+    }
+
+    let offset = n.get_child_value("offset").unwrap();
+    let c = REGEXES.get().unwrap().offset_re.captures(&offset).unwrap();
+    let spacing = u32::from_str_radix(c.get(3).unwrap().as_str(), 16).unwrap();
+    Some(ArrayInfo { size, spacing })
+}
+
 fn convert(raw: RawNode) -> Result<RegMap> {
     let definitions = match raw.find_descendant_container("definitions") {
         Some(RawNode::Container { children, .. }) => children,
@@ -373,14 +421,26 @@ fn convert(raw: RawNode) -> Result<RegMap> {
 
     let mut address_maps = Vec::new();
     let mut registers = Vec::new();
+    let mut arrays = BTreeMap::new();
     for d in definitions.iter() {
+        if let Some(a) = get_array_info(d) {
+            let name = d
+                .get_child_value("referenceName")
+                .unwrap()
+                .as_str()
+                .to_string();
+            arrays.insert(name, a);
+        }
         match d.get_child_value("referenceType").unwrap().as_str() {
             "addressmap" => {
                 // Some sections tagged as "addressMap" don't actually
                 // contain any map entries.
-                if let Some(root) = d.find_descendant_container("addressMap") {
-                    address_maps.push(AddressMap::try_from(root).map_err(|e| {
-                    anyhow!( "failed to convert {root:#?} to an addressmap: {e:?}")})?)
+                if d.find_descendant_container("addressMap").is_some() {
+                    address_maps.push(AddressMap::try_from(d).map_err(|e| {
+                        anyhow!(
+                            "failed to convert {d:#?} to an addressmap: {e:?}"
+                        )
+                    })?)
                 }
             }
             "register" => {
@@ -397,10 +457,11 @@ fn convert(raw: RawNode) -> Result<RegMap> {
         }
     }
 
-    Ok(RegMap { address_maps, registers })
+    Ok(RegMap { address_maps, registers, arrays })
 }
 
 pub fn parse_xml(xml: &String) -> Result<RegMap> {
+    init_regexes();
     let file = File::open(xml)?;
     let reader = BufReader::new(file);
     let mut parser = Parser::new(reader);

--- a/xml2rsf/src/rsf.rs
+++ b/xml2rsf/src/rsf.rs
@@ -27,15 +27,11 @@ struct Regexes {
 static REGEXES: OnceLock<Regexes> = OnceLock::new();
 
 fn init_regexes() {
-    std::thread::spawn(|| {
-        let _ = REGEXES.get_or_init(|| Regexes {
-            normalize_re: regex::Regex::new(r"\[[\d -]+\]").unwrap(),
-            single_re: Regex::new(r"\.*\[\s*(\d+)\s*\]").unwrap(),
-            range_re: Regex::new(r"\.*\[(\d+)\s*-\s*(\d+)\]").unwrap(),
-        });
-    })
-    .join()
-    .unwrap()
+    let _ = REGEXES.get_or_init(|| Regexes {
+        normalize_re: regex::Regex::new(r"\[[\d+ -]+\]").unwrap(),
+        single_re: Regex::new(r"\.*\[\s*(\d+)\s*\]").unwrap(),
+        range_re: Regex::new(r"\.*\[(\d+)\s*-\s*(\d+)\]").unwrap(),
+    });
 }
 
 struct Indexes {
@@ -47,6 +43,7 @@ struct Indexes {
 #[derive(Debug, Clone)]
 struct Block<'a> {
     full_name: String,
+    ref_name: String,
     name: String,
     low_offset: u32,
     high_offset: u32,
@@ -69,12 +66,14 @@ struct RegisterInstance<'a> {
 impl<'a> Block<'a> {
     pub fn new(
         full_name: String,
+        ref_name: String,
         name: String,
         low_offset: u32,
         high_offset: u32,
     ) -> Self {
         Block {
             full_name,
+            ref_name,
             name,
             low_offset,
             high_offset,
@@ -93,7 +92,13 @@ fn build_block_tree<'a>(map: &'a RegMap) -> Result<Block<'a>> {
         .map(|r| (r.ref_name.clone(), r))
         .collect::<BTreeMap<String, &Register>>();
 
-    let mut root = Block::new("main".to_string(), "main".to_string(), 0, 0);
+    let mut root = Block::new(
+        "main".to_string(),
+        "main".to_string(),
+        "main".to_string(),
+        0,
+        0,
+    );
     for a in &map.address_maps {
         for e in &a.entries {
             let Some(name) = &e.name else {
@@ -127,8 +132,10 @@ fn build_block_tree<'a>(map: &'a RegMap) -> Result<Block<'a>> {
                     break;
                 } else {
                     full_name = format!("{full_name}.{p}");
+                    let ref_name = e.ref_name.as_ref().unwrap().clone();
                     b = b.blocks.entry(p.to_string()).or_insert(Block::new(
                         full_name.clone(),
+                        ref_name,
                         p.to_string(),
                         e.low,
                         e.high,
@@ -218,9 +225,9 @@ fn name_normalize(name: &str) -> String {
 //     jbay_reg.device_select.lfltr[2].hash[1].hash_array[0 - 15]
 //     jbay_reg.device_select.lfltr[2].hash[2].hash_array[0 - 15]
 //     jbay_reg.device_select.lfltr[2].hash[3].hash_array[0 - 15]
-fn build_arrays(state: &mut ArrayBuilderState, tree: &mut Block) {
+fn build_arrays(rm: &RegMap, state: &mut ArrayBuilderState, tree: &mut Block) {
     for b in tree.blocks.values_mut() {
-        build_arrays(state, b);
+        build_arrays(rm, state, b);
     }
     state.reset();
     for b in tree.blocks.values_mut() {
@@ -228,10 +235,10 @@ fn build_arrays(state: &mut ArrayBuilderState, tree: &mut Block) {
     }
     for (name, array) in &mut state.arrays {
         let mut block = tree.blocks.get(&array.elements[0]).unwrap().clone();
+        let asize = rm.arrays.get(&block.ref_name).unwrap();
         block.name = name.clone();
-        block.count = (array.high_idx + 1) - array.low_idx;
-        block.spacing =
-            ((array.high_offset + 1) - array.low_offset) / block.count;
+        block.count = asize.size;
+        block.spacing = asize.spacing;
         block.low_offset = array.low_offset;
         block.high_offset = array.high_offset;
         while let Some(e) = array.elements.pop() {
@@ -247,9 +254,10 @@ fn build_arrays(state: &mut ArrayBuilderState, tree: &mut Block) {
     }
     for (name, array) in &mut state.arrays {
         let mut reg = tree.regs.get_mut(&array.elements[0]).unwrap().clone();
+        let asize = rm.arrays.get(&reg.reference.ref_name).unwrap();
         reg.instance_name = name.clone();
-        reg.count = (array.high_idx + 1) - array.low_idx;
-        reg.spacing = ((array.high_offset + 1) - array.low_offset) / reg.count;
+        reg.count = asize.size;
+        reg.spacing = asize.spacing;
         reg.low_offset = array.low_offset;
         reg.high_offset = array.high_offset;
         while let Some(e) = array.elements.pop() {
@@ -482,15 +490,13 @@ pub fn convert(map: RegMap) -> Result<ast::Ast> {
     let registers =
         indexes.map.registers.iter().map(|r| r.ref_name.clone()).collect();
     let mut block_tree = build_block_tree(&indexes.map)?;
-
     let mut ab = ArrayBuilderState::new();
-    build_arrays(&mut ab, &mut block_tree);
+    build_arrays(&indexes.map, &mut ab, &mut block_tree);
 
     let mut blocks = BTreeSet::<String>::new();
     all_block_names(&block_tree, &mut blocks);
     indexes.registers = uniquify(registers);
     indexes.blocks = uniquify(blocks.into_iter().collect());
-    println!("{:#?}", indexes.blocks);
     {
         // The registers and blocks all live in a single flat namespace,
         // unless we break it into multiple files.  Make sure we have no


### PR DESCRIPTION
Add support for poll()ing on the device file.
Add support for reading shadow interrupt information. Derived array bounds are occasionally incorrect.  Use the bounds explicitly defined in the register map definition. add an API to get the tofino driver version